### PR TITLE
feature: include chalk library in the project

### DIFF
--- a/conteudo/talk-01/sample/index.ts
+++ b/conteudo/talk-01/sample/index.ts
@@ -1,10 +1,10 @@
 import normalizarNomeCompleto from "./lib/index.ts";
-
+import mensagemSucesso from "./mensagens/sucesso.mensagem.ts";
 
 function main() {
     const entradaDigitadaNoTerminal = process.argv[2];
-    const nomeOuErro = normalizarNomeCompleto(entradaDigitadaNoTerminal);
-    console.log(nomeOuErro);
+    const nome = normalizarNomeCompleto(entradaDigitadaNoTerminal);
+    mensagemSucesso(`Nome digitado: ${nome}`);
 };
 
 main();

--- a/conteudo/talk-01/sample/mensagens/sucesso.mensagem.ts
+++ b/conteudo/talk-01/sample/mensagens/sucesso.mensagem.ts
@@ -1,0 +1,7 @@
+import chalk from 'chalk';
+
+const mensagemSucesso = (mensagem: string): void => {
+  console.error(chalk.green(`${mensagem}`));
+};
+
+export default mensagemSucesso

--- a/conteudo/talk-01/sample/package.json
+++ b/conteudo/talk-01/sample/package.json
@@ -9,7 +9,8 @@
     "formatar-nome": "node --experimental-strip-types index.ts"
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
-    "@types/node": "^22.5.4"
+    "@types/node": "^22.5.4",
+    "chalk": "^5.3.0",
+    "typescript": "^5.6.2"
   }
 }


### PR DESCRIPTION
- Incluí a library `chalk`
- Inclui o uso dessa funcionalidade para printar mensagens de sucesso
- Eu modifiquei a variável nomeOuErro para `nome` porque mesmo em cenário de falha ele não vai retornar um erro nessa constante